### PR TITLE
Parametrize the one-click install script

### DIFF
--- a/scripts/openyonclickinstall.sh
+++ b/scripts/openyonclickinstall.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # To get the latest stable OpenY on DigitalOcean 16.04 LST x64 droplet run the command:
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s
+#   curl -Ls http://bit.ly/initopeny | bash -s
 #   or
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s stable
+#   curl -Ls http://bit.ly/initopeny | bash -s stable
 # To get the latest dev:
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev
+#   curl -Ls http://bit.ly/initopeny | bash -s dev
 # To get the latest beta:
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s beta
+#   curl -Ls http://bit.ly/initopeny | bash -s beta
 # To get a particular version:
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s 8.1.10
+#   curl -Ls http://bit.ly/initopeny | bash -s 8.1.10
 # To get a particular branch:
-#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev-BRANCH_NAME
+#   curl -Ls http://bit.ly/initopeny | bash -s dev-BRANCH_NAME
 # as root user
 
 OPENYBETA="8.2.*@beta"

--- a/scripts/openyonclickinstall.sh
+++ b/scripts/openyonclickinstall.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# To get OpenY on DigitalOcean 16.04 LST x64 droplet run the command:
-# bash < <(curl -Ls http://bit.ly/initopeny)
+# To get latest dev OpenY on DigitalOcean 16.04 LST x64 droplet run the command:
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s
+# To get particular version or branch:
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s 8.1.10
 # as root user
+
+OPENYBETA="8.2.*@beta"
+OPENYDEV="dev-8.x-1.x"
+
+OPENYVERSION="$1"
+OPENYVERSION=${OPENYVERSION:-stable}
+
 printf "Hello, OpenY evaluator.\n OpenY one click install version 1.4.\n"
 
 printf "Installing OpenY into /var/www/html\n"
@@ -41,7 +50,25 @@ printf "\nPreparing OpenY code tree \n"
 sudo rm -rf /var/www/html.bak/html || true
 sudo mv /var/www/html /var/www/html.bak || true
 composer create-project ymcatwincities/openy-project:8.1.x-dev /var/www/html --no-interaction
-cd /var/www/html/ && composer update
+cd /var/www/html/
+
+# Check if the Open Y version must be adjusted.
+if [[ "$OPENYVERSION" == "stable" ]]; then
+  echo "Installing Latest Stable Open Y"
+elif [[ "$OPENYVERSION" == "dev" ]]; then
+  echo "Installing Latest Dev Open Y"
+  composer remove ymcatwincities/openy --no-update
+  composer require ymcatwincities/openy:${OPENYDEV} --update-with-dependencies
+elif [[ "$OPENYVERSION" == "beta" ]]; then
+  echo "Installing Latest Beta Open Y"
+  composer remove ymcatwincities/openy --no-update
+  composer require ymcatwincities/openy:${OPENYBETA} --update-with-dependencies
+else
+  echo "Installing Open Y $OPENYVERSION"
+  composer remove ymcatwincities/openy --no-update
+  composer require ymcatwincities/openy:${OPENYVERSION} --update-with-dependencies
+fi
+composer update
 
 cp /tmp/drupal/sites/default/settings.php /var/www/html/docroot/sites/default/settings.php
 sudo mkdir /var/www/html/docroot/sites/default/files

--- a/scripts/openyonclickinstall.sh
+++ b/scripts/openyonclickinstall.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
-# To get latest dev OpenY on DigitalOcean 16.04 LST x64 droplet run the command:
+# To get the latest stable OpenY on DigitalOcean 16.04 LST x64 droplet run the command:
 #   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s
-# To get particular version or branch:
+#   or
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s stable
+# To get the latest dev:
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev
+# To get the latest beta:
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s beta
+# To get a particular version:
 #   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s 8.1.10
+# To get a particular branch:
+#   curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev-BRANCH_NAME
 # as root user
 
 OPENYBETA="8.2.*@beta"


### PR DESCRIPTION
The PR introduces parametrization of the one-click install script.

The first argument might take the following values:
- `stable` - the script installs latest stable version of Open Y (e.g. `8.1.13.2`), the default value
- `dev` - installs the latest dev version of Open Y (branch `8.x-1.x`)
- `beta` - installs the latest beta release (e.g. `8.2.0.0-beta`)
- any other value with prefix `dev-` - installs from the branch (e.g. `dev-decoupling` installs from `decoupling` branch) if the branch exists, otherwise installs the latest stable
- any other value - installs the Open Y of this version if it exists or the latest stable if the provided version doesn't exist (e.g. `8.1.10` installs Open Y 8.1.10, `abracadabra` installs the latest stable Open Y)


Steps for review:
- get a Digital Ocean Ubuntu 16.04 LTS droplet
- execute `curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s` (equal to 'curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s **stable**')
- verify the latest stable version of Open Y has been fetched and ready to be installed
- execute `curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev`
- verify the latest dev version of Open Y has been fetched and ready to be installed
- execute `curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev-decoupling`
- verify the branch `decoupling` of Open Y repo is used as a source for Open Y profile, it's been downloaded and ready to be installed once the script is done.
- execute `curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s beta`
- verify the [latest beta release of Open Y](https://github.com/ymcatwincities/openy/releases/tag/8.2.0.0-beta) is used as a source for Open Y profile, it's been downloaded and ready to be installed once the script is done.

Once the PR is merged the link to the script can be reverted to the shortened one.

P.S. I noticed that the `vhost.conf` of apache2 is rewritten incorrectly any time but the first time the script is used.
![image](https://user-images.githubusercontent.com/5453109/48149963-7cd0d000-e2ce-11e8-9a2a-d1b619d42ff3.png)
See how `DocumentRoot` and `Directory` directives look.
The file is at `/etc/apache2/sites-enabled/vhosts.conf`
Not sure if the fix should be included in the PR.