### PR TITLE
Set up locale if it hasn't been set

### DIFF
--- a/scripts/openyonclickinstall.sh
+++ b/scripts/openyonclickinstall.sh
@@ -19,6 +19,12 @@ OPENYDEV="dev-8.x-1.x"
 OPENYVERSION="$1"
 OPENYVERSION=${OPENYVERSION:-stable}
 
+# Set up locale if it's missed
+[ -z "$LC_ALL" ] && export LC_ALL=en_US.UTF-8
+[ -z "$LANGUAGE" ] && export LANGUAGE=en_US.UTF-8
+[ -z "$LC_CTYPE" ] && export LC_TYPE=en_US.UTF-8
+[ -z "$LANG" ] && export LANG=en_US.UTF-8
+
 printf "Hello, OpenY evaluator.\n OpenY one click install version 1.4.\n"
 
 printf "Installing OpenY into /var/www/html\n"


### PR DESCRIPTION
If locale is not set, then `pip` installation fails.

It was the case on DigitalOcean NYC3 ubuntu 16.04.4

The proposed change fixes the issue.

To test it before the PR is merged
`curl -Ls https://raw.githubusercontent.com/AndreyMaximov/openy-project/8.1.x/scripts/openyonclickinstall.sh | bash -s dev-8.x-2.x`