### PR TITLE
drupal-scaffold upgraded to 2.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ymcatwincities/openy": "8.*.*",
         "composer/installers": "^1.2",
-        "drupal-composer/drupal-scaffold": "^2.2",
+        "drupal-composer/drupal-scaffold": "^2.5.0",
         "cweagans/composer-patches": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
In order to fix fatal error on composer update, we should update drupal scaffold
https://github.com/drupal-composer/drupal-scaffold/issues/79
```
Fatal error: Uncaught TypeError: Argument 3 passed to DrupalComposer\DrupalScaffold\FileFetcher::__construct() must implement interface Composer\IO\IOInterface, array given, called in /var/www/vendor/drupal-composer/drupal-scaffold/src/Handler.php on line 116 and defined in /var/www/vendor/drupal-composer/drupal-scaffold/src/FileFetcher.php:38
```