### PR TITLE
OS-youtube-popup-fix: add prefix for library name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         {
             "type": "package",
             "package": {
-                "name": "grt-youtube-popup",
+                "name": "grt107/grt-youtube-popup",
                 "version": "1.0.0",
                 "type": "drupal-library",
                 "source": {


### PR DESCRIPTION
Fix for 
"
Problem 1
    - ymcatwincities/openy 8.2.0.7 requires grt-youtube-popup ^1.0 -> no matching package found.
...
"
error message during installation.