### PR TITLE
Add drupal console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "2.4.0",
         "cweagans/composer-patches": "~1.0",
-        "drupal/console": "1.9.2",
-        "drupal/console-core": "1.9.2",
-        "drupal/console-en": "1.9.2"
+        "drupal/console": "1.9.2"
     },
     "require-dev": {
         "ymcatwincities/openy-cibox-build": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
         "ymcatwincities/openy": "8.2.*",
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "2.4.0",
-        "cweagans/composer-patches": "~1.0"
+        "cweagans/composer-patches": "~1.0",
+        "drupal/console": "1.9.2",
+        "drupal/console-core": "1.9.2",
+        "drupal/console-en": "1.9.2"
     },
     "require-dev": {
         "ymcatwincities/openy-cibox-build": "dev-master",


### PR DESCRIPTION
Looks like there is no way to add drupal console to openy, only to openy-project

```sh
vagrant up && vagrant ssh
cd /var/www/docroot
../vendor/drupal/console/bin/drupal
```

Let me know what you think.