### PR TITLE
[RGTC-535] Fix deprecated attribute in yparse.sh

### DIFF
--- a/scripts/yparse.sh
+++ b/scripts/yparse.sh
@@ -3,7 +3,7 @@
 join_by() { local IFS="$1"; shift; echo "$*"; }
 
 yaml() {
-    python -c "import yaml;print(' '.join(str(x) for x in yaml.load(open('$1'),Loader=yaml.FullLoader)$2))"
+    python -c "import yaml;print(' '.join(str(x) for x in yaml.load(open('$1'))$2))"
 }
 
 VALUE=$(yaml ./openy.info.yml "['dependencies']")


### PR DESCRIPTION
### Steps to review:

- [ ] Run `sh yparse.sh | xargs drush en -y` when upgrading to new version openy
- [ ] You should not see any errors